### PR TITLE
add landing page for users to enter their Spotify client ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -3244,6 +3245,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -14718,6 +14727,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+      "dependencies": {
+        "@remix-run/router": "1.16.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+      "dependencies": {
+        "@remix-run/router": "1.16.1",
+        "react-router": "6.23.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -7,40 +7,17 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&family=Quattrocento+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#B5DD88" />
     <meta
       name="description"
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+    <link rel="manifest" href="manifest.json" />
     <title>Jammming</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Jammming",
+  "name": "Spotify Playlist Creator",
   "icons": [
     {
       "src": "favicon.png",
@@ -20,6 +20,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#B5DD88",
+  "background_color": "#00A547"
 }

--- a/src/components/landing.js
+++ b/src/components/landing.js
@@ -1,0 +1,52 @@
+import React, { useState, useCallback } from 'react';
+import '../styles/landing.css';
+import Spotify from '../util/spotify';
+import favicon from '../util/images/favicon.png';
+
+function Landing() {
+  const [input, setInput] = useState('');
+
+  const handleInputChange = useCallback(
+    event => {
+      setInput(event.target.value);
+    },
+    []
+  );
+
+  const onSubmit = useCallback(
+    event => {
+      event.preventDefault();
+      const clientId = encodeURIComponent(input);
+      Spotify.getAccessToken(clientId);
+  },
+  [input]
+);
+
+
+  return (
+    <div>
+        <div className='heading'>
+          <img className='logo' src={favicon} alt='Jammming logo'/>
+          <h1>
+            Ja<span className='mmm'>mmm</span>ing
+          </h1>
+        </div>
+        <div className='form'>
+          <h2>This application requires a Spotify Client ID</h2>
+          <p>Please Enter Your Spotify Client ID below. If you need a Spotify Client ID or are unsure of your client ID, please visit the <a href='https://developer.spotify.com/documentation/web-api/concepts/apps' target='_blank'>Spotify Developers Portal</a>.</p>
+          <p className='note'>(<b>Note:</b> This app does not save any of your information and is not connected to any kind of database. Your Spotify credentials and client ID are safe and cannot be seen or used by anyone else.)</p>
+          <form>
+            <input
+              placeholder='Enter your Spotify Client ID'
+              onChange={handleInputChange}
+            />
+            <button onClick={onSubmit}>
+              Submit
+            </button>
+          </form>
+        </div>
+      </div>
+  );
+}
+
+export default Landing;

--- a/src/components/playlist.js
+++ b/src/components/playlist.js
@@ -12,7 +12,7 @@ function Playlist(props) {
   return (
     <div>
       <h2>Playlist</h2>
-      <input onChange={handleNameChange} placeholder='Name Your Playlist' />
+      <input onChange={handleNameChange} placeholder='Name your playlist' />
       <button onClick={props.onSave}>
         Save To Spotify
       </button>

--- a/src/components/searchbar.js
+++ b/src/components/searchbar.js
@@ -21,7 +21,7 @@ function SearchBar(props) {
     <div>
       <h2>Search</h2>
       <input
-        placeholder='Enter A Song Title'
+        placeholder='Enter a song, artist or album'
         onChange={handleInputChange}
       />
       <button onClick={search}>

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import App from './components/app';
+import Landing from './components/landing';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <BrowserRouter>
+    <Routes>
+      <Route exact path='/' element={<Landing />}/>
+      <Route exact path='/app/callback' element={<App />}/>
+    </Routes>
+  </BrowserRouter>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -61,5 +61,4 @@ h2 {
   margin: 1rem 0;
   padding: 0 0.7rem;
   text-align: center;
-  
 }

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -1,0 +1,49 @@
+body {
+  margin: 0;
+}
+
+.heading {
+  margin: 0 auto;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: 'Oswald', sans-serif;
+  font-size: 2rem;
+  letter-spacing: 0.2rem;
+}
+
+h1 {
+  margin: 0;
+}
+
+.mmm {
+  color: #00A547;
+}
+
+.logo {
+  width: 3rem;
+  height: 3rem;
+  margin-right: 1rem;
+  margin-top: 0.4rem;
+}
+
+h2 {
+  font-family: 'Osw', sans-serif;
+  margin: 1rem 0;
+}
+
+p {
+  margin: 1.5rem;
+}
+
+.form {
+  text-align: center;
+  margin: 0 auto;
+  width: 40rem;
+}
+
+.note {
+  font-style: italic;
+  font-size: .85rem;
+}

--- a/src/util/spotify.js
+++ b/src/util/spotify.js
@@ -1,9 +1,8 @@
-const clientId = encodeURIComponent('');
-const redirectUri = encodeURIComponent('http://localhost:3000/callback');
+const redirectUri = encodeURIComponent('http://localhost:3000/app/callback');
 let accessToken;
 
 const Spotify = {
-  getAccessToken() {
+  getAccessToken(clientId) {
     if(accessToken) {
       return encodeURIComponent(accessToken);
     }


### PR DESCRIPTION
Implement a landing page that prompts users to enter their Spotify client ID to simplify the process of adding the client ID required for the app to work. Currently, users must manually add their client ID in the spotify.js file.